### PR TITLE
Small fix for AttributeError: 'NoneType' object has no attribute 'step'

### DIFF
--- a/core/train.py
+++ b/core/train.py
@@ -71,7 +71,7 @@ def build_model(checkpoints, config, device):
     print(optim)
     optim.set_parameters(model.parameters())
     if checkpoints is not None:
-        optim = optim.optimizer.load_state_dict(checkpoints["optim"])
+        optim.optimizer.load_state_dict(checkpoints["optim"])
 
     param_count = sum([param.view(-1).size()[0] for param in model.parameters()])
     print(repr(model) + "\n\n")


### PR DESCRIPTION
Hello!

I was trying to continue training from a checkpoint and ran into this issue.
`load_state_dict` method doesn't return anything so this assignment will update `optim` as `None`
This is a small fix.

Best,
Mariko